### PR TITLE
IWE-111: Made changes to Watson Relevance Score Min and implemented limits to tags

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -869,7 +869,7 @@ class ProjectController extends Controller
     public function getWatsonTags(Request $request, $data = null)
     {   
         $relevance = env('WATSON_RELEVANCE_MIN');
-        $tagLimit = env('WATSON_RESULT_LIMIT');
+        $tagLimit = (int) env('WATSON_RESULT_LIMIT');
         if($request->filled('data')){
             $data = $request->get('data');
         }
@@ -877,7 +877,6 @@ class ProjectController extends Controller
         $model = new AnalyzeModel($data, ['concepts'=>['limit'=> $tagLimit]]);
         $result = $nlu->analyze($model);
         $responseData =  json_decode($result->getContent());
-
         if($responseData){
             $data = array_filter($responseData->concepts, function ($tag) use ($relevance) { 
                 return ($tag->relevance >= $relevance);

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -866,13 +866,15 @@ class ProjectController extends Controller
         return $newAttributeValues->count();
     }
 
-    public function getWatsonTags(Request $request, $data = null, $relevance = 0.5)
+    public function getWatsonTags(Request $request, $data = null)
     {   
+        $relevance = env('WATSON_RELEVANCE_MIN');
+        $tagLimit = env('WATSON_RESULT_LIMIT');
         if($request->filled('data')){
             $data = $request->get('data');
         }
         $nlu = new NaturalLanguageUnderstanding( WatsonCredential::initWithCredentials(env('WATSON_USER_NAME'), env('WATSON_PASSWORD')) );
-        $model = new AnalyzeModel($data, ['concepts'=>['limit'=>50]]);
+        $model = new AnalyzeModel($data, ['concepts'=>['limit'=> $tagLimit]]);
         $result = $nlu->analyze($model);
         $responseData =  json_decode($result->getContent());
 

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -118,7 +118,7 @@ class Project extends Model
 
     public function tags()
     {
-        return $this->hasMany('Helix\Models\Tag', 'project_id', 'project_id');
+        return $this->hasMany('Helix\Models\Tag', 'project_id', 'project_id')->where('relevance','>=',env('WATSON_RELEVANCE_MIN'));
     }
 
     public function department()


### PR DESCRIPTION
### `IWE-111` - `PR`
`**READY**`

### Migrations
`NO`

### What's this PR do?
`Adjust Watson's relevance min and limit to tags returned`
### Where should the reviewer start?  
`Ensure current projects with tags lower than .75 relevance are not returned, Watson only returns tags with .75+ , and is limited to 10 max.`

### Requirements & Dependencies

`Changes to env values.`

### Steps to Test or Reproduce
ENV Additions:
```sh
WATSON_RELEVANCE_MIN=.75
WATSON_RESULT_LIMIT=10
```

### Impacted Areas in Application
`IBM Watson`